### PR TITLE
Configure Vercel deployment for frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,3 +190,19 @@ The `frontend/` directory now contains a Vite-powered React prototype that bring
 - **Reports:** Filter controls, stacked/line charts, and a monthly summary table ready for export actions.
 
 Run `npm install` followed by `npm run dev` inside `frontend/` to explore the experience locally.
+
+## Deployment
+
+### Vercel
+
+This repository includes a `vercel.json` configuration that lets you deploy the React frontend located in `frontend/` directly to Vercel:
+
+1. Create a new project in Vercel and select this repository.
+2. When prompted for project settings, set the root directory to `frontend/` or leave it empty—Vercel reads `vercel.json` at the repository root to discover the build.
+3. Confirm the following settings (automatically inferred by the configuration):
+   - **Build Command:** `npm run build`
+   - **Install Command:** `npm install`
+   - **Output Directory:** `dist`
+4. Deploy the project. The included route configuration ensures that client-side routing falls back to `index.html` so React Router works correctly on Vercel.
+
+For local verification of the production build, run `npm run build` inside `frontend/` to generate the optimized assets in `frontend/dist/`.

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,16 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "frontend/package.json",
+      "use": "@vercel/static-build",
+      "config": {
+        "distDir": "dist"
+      }
+    }
+  ],
+  "routes": [
+    { "handle": "filesystem" },
+    { "src": "/.*", "dest": "/index.html" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a Vercel configuration that builds and serves the Vite frontend from the `frontend` directory
- document the deployment workflow so the app can be published on Vercel

## Testing
- npm install *(fails: registry access is forbidden in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d663f3d928832cb5c28141297184e4