### PR TITLE
Fix Vercel deployment configuration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,16 +1,7 @@
 {
-  "version": 2,
-  "builds": [
-    {
-      "src": "frontend/package.json",
-      "use": "@vercel/static-build",
-      "config": {
-        "distDir": "dist"
-      }
-    }
-  ],
-  "routes": [
-    { "handle": "filesystem" },
-    { "src": "/.*", "dest": "/index.html" }
+  "buildCommand": "npm install --prefix frontend && npm run build --prefix frontend",
+  "outputDirectory": "frontend/dist",
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
   ]
 }


### PR DESCRIPTION
## Summary
- switch to a monorepo-friendly Vercel configuration that installs and builds from the frontend directory
- point Vercel at the built Vite output and add a catch-all rewrite for SPA routing

## Testing
- npm install *(fails: registry access forbidden in execution environment)*
- npm run build *(fails: vite binary missing because install failed)*

------
https://chatgpt.com/codex/tasks/task_e_68d66679ab50832cbbbff292ecb48e25