### PR TITLE
Add internationalization support and compact timeline table

### DIFF
--- a/frontend/src/components/cards/CulturalSpotlight.jsx
+++ b/frontend/src/components/cards/CulturalSpotlight.jsx
@@ -1,8 +1,12 @@
+import { useAppContext } from '../../context/AppContext.jsx';
+
 export default function CulturalSpotlight({ item }) {
+  const { t } = useAppContext();
+
   return (
     <article className={`spotlight-card ${item.accent}`}>
-      <h3>{item.title}</h3>
-      <p>{item.description}</p>
+      <h3>{t(`dashboard.spotlights.${item.id}.title`)}</h3>
+      <p>{t(`dashboard.spotlights.${item.id}.description`)}</p>
     </article>
   );
 }

--- a/frontend/src/components/cards/QuickAddCard.jsx
+++ b/frontend/src/components/cards/QuickAddCard.jsx
@@ -2,15 +2,15 @@ import PillButton from '../shared/PillButton.jsx';
 import { useAppContext } from '../../context/AppContext.jsx';
 
 export default function QuickAddCard() {
-  const { openModal } = useAppContext();
+  const { openModal, t } = useAppContext();
   return (
     <article className="quick-add-card">
-      <h3>Quick Add</h3>
-      <p>Captura ingresos y gastos con toques culturales personalizados.</p>
+      <h3>{t('dashboard.quickAdd.title')}</h3>
+      <p>{t('dashboard.quickAdd.description')}</p>
       <div className="quick-add-actions">
-        <PillButton onClick={() => openModal('income')}>Add Income</PillButton>
+        <PillButton onClick={() => openModal('income')}>{t('dashboard.quickAdd.addIncome')}</PillButton>
         <PillButton variant="secondary" onClick={() => openModal('expense')}>
-          Add Expense
+          {t('dashboard.quickAdd.addExpense')}
         </PillButton>
       </div>
     </article>

--- a/frontend/src/components/cards/TimelineCard.jsx
+++ b/frontend/src/components/cards/TimelineCard.jsx
@@ -1,18 +1,54 @@
+import { useMemo } from 'react';
+import { useAppContext } from '../../context/AppContext.jsx';
+
 export default function TimelineCard({ transactions }) {
+  const { t, locale } = useAppContext();
+  const headers = t('dashboard.timeline.headers');
+
+  const currencyFormatter = useMemo(
+    () =>
+      new Intl.NumberFormat(locale, {
+        style: 'currency',
+        currency: 'EUR',
+        signDisplay: 'always',
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 0
+      }),
+    [locale]
+  );
+
+  const dateFormatter = useMemo(
+    () => new Intl.DateTimeFormat(locale, { dateStyle: 'medium' }),
+    [locale]
+  );
+
   return (
     <article className="timeline-card">
-      <h3>Recent Activity</h3>
-      <ul>
-        {transactions.map((tx) => (
-          <li key={tx.id} className={tx.tone}>
-            <div>
-              <p>{tx.label}</p>
-              <span className="tx-tag">{tx.tag}</span>
-            </div>
-            <span className="tx-amount">{tx.amount}</span>
-          </li>
-        ))}
-      </ul>
+      <h3>{t('dashboard.timeline.title')}</h3>
+      <table className="timeline-table">
+        <thead>
+          <tr>
+            <th>{headers.name}</th>
+            <th>{headers.person}</th>
+            <th>{headers.date}</th>
+            <th className="align-right">{headers.amount}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {transactions.map((tx) => {
+            const amount = currencyFormatter.format(tx.amount);
+            const formattedDate = dateFormatter.format(new Date(tx.date));
+            return (
+              <tr key={tx.id} className={`timeline-row ${tx.tone}`}>
+                <td>{t(`dashboard.timeline.items.${tx.name}`)}</td>
+                <td>{tx.person}</td>
+                <td>{formattedDate}</td>
+                <td className={tx.amount >= 0 ? 'tx-amount positive' : 'tx-amount negative'}>{amount}</td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
     </article>
   );
 }

--- a/frontend/src/components/charts/ExpenseDonut.jsx
+++ b/frontend/src/components/charts/ExpenseDonut.jsx
@@ -1,4 +1,6 @@
+import { useMemo } from 'react';
 import { Cell, Pie, PieChart, ResponsiveContainer, Tooltip } from 'recharts';
+import { useAppContext } from '../../context/AppContext.jsx';
 
 const patternFill = (
   <pattern id="talavera" patternUnits="userSpaceOnUse" width="8" height="8">
@@ -9,31 +11,49 @@ const patternFill = (
 );
 
 export default function ExpenseDonut({ data }) {
+  const { t, locale } = useAppContext();
+
+  const localizedData = useMemo(
+    () => data.map((entry) => ({ ...entry, name: t(`dashboard.expenseBreakdown.${entry.id}`) })),
+    [data, t]
+  );
+
+  const currencyFormatter = useMemo(
+    () =>
+      new Intl.NumberFormat(locale, {
+        style: 'currency',
+        currency: 'EUR',
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 0
+      }),
+    [locale]
+  );
+
   return (
     <div className="chart-card">
       <svg width="0" height="0">
         <defs>{patternFill}</defs>
       </svg>
-      <h3>Expense Breakdown</h3>
+      <h3>{t('dashboard.charts.expenseBreakdown')}</h3>
       <ResponsiveContainer width="100%" height={240}>
         <PieChart>
           <Pie
-            data={data}
+            data={localizedData}
             dataKey="value"
             nameKey="name"
             innerRadius={60}
             outerRadius={90}
             paddingAngle={4}
           >
-            {data.map((entry) => (
+            {localizedData.map((entry) => (
               <Cell key={entry.name} fill={entry.fill} stroke="none" />
             ))}
           </Pie>
-          <Tooltip formatter={(value, name) => [`€${value}`, name]} />
+          <Tooltip formatter={(value, name) => [currencyFormatter.format(value), name]} />
         </PieChart>
       </ResponsiveContainer>
       <div className="chart-legend">
-        {data.map((entry) => (
+        {localizedData.map((entry) => (
           <span key={entry.name}>
             <span className="legend-dot" style={{ backgroundColor: entry.fill }} />
             {entry.name}

--- a/frontend/src/components/charts/IncomeStreamsChart.jsx
+++ b/frontend/src/components/charts/IncomeStreamsChart.jsx
@@ -1,15 +1,35 @@
+import { useMemo } from 'react';
 import { Bar, BarChart, CartesianGrid, Legend, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import { useAppContext } from '../../context/AppContext.jsx';
 
 export default function IncomeStreamsChart({ data }) {
+  const { t, locale } = useAppContext();
+
+  const localizedData = useMemo(
+    () => data.map((entry) => ({ ...entry, name: t(`dashboard.incomeStreams.${entry.id}`) })),
+    [data, t]
+  );
+
+  const currencyFormatter = useMemo(
+    () =>
+      new Intl.NumberFormat(locale, {
+        style: 'currency',
+        currency: 'EUR',
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 0
+      }),
+    [locale]
+  );
+
   return (
     <div className="chart-card">
-      <h3>Income Streams</h3>
+      <h3>{t('dashboard.charts.incomeStreams')}</h3>
       <ResponsiveContainer width="100%" height={260}>
-        <BarChart data={data}>
+        <BarChart data={localizedData}>
           <CartesianGrid strokeDasharray="3 3" vertical={false} />
           <XAxis dataKey="name" tick={{ fill: '#2b2b2b' }} />
           <YAxis tick={{ fill: '#2b2b2b' }} />
-          <Tooltip formatter={(value) => [`€${value}`, 'Amount']} />
+          <Tooltip formatter={(value) => [currencyFormatter.format(value), t('dashboard.charts.tooltipAmount')]} />
           <Legend />
           <Bar dataKey="paola" stackId="a" fill="#E94256" name="Paola" />
           <Bar dataKey="carlo" stackId="a" fill="#1F3C88" name="Carlo" />

--- a/frontend/src/components/charts/SavingsProjectionChart.jsx
+++ b/frontend/src/components/charts/SavingsProjectionChart.jsx
@@ -1,14 +1,34 @@
+import { useMemo } from 'react';
 import { Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import { useAppContext } from '../../context/AppContext.jsx';
 
 export default function SavingsProjectionChart({ data }) {
+  const { t, locale } = useAppContext();
+
+  const localizedData = useMemo(
+    () => data.map((entry) => ({ ...entry, month: t(`reports.months.${entry.month}`) })),
+    [data, t]
+  );
+
+  const currencyFormatter = useMemo(
+    () =>
+      new Intl.NumberFormat(locale, {
+        style: 'currency',
+        currency: 'EUR',
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 0
+      }),
+    [locale]
+  );
+
   return (
     <div className="chart-card">
-      <h3>Savings Projection</h3>
+      <h3>{t('reports.charts.savingsTitle')}</h3>
       <ResponsiveContainer width="100%" height={280}>
-        <LineChart data={data}>
+        <LineChart data={localizedData}>
           <XAxis dataKey="month" tick={{ fill: '#333' }} />
           <YAxis tick={{ fill: '#333' }} />
-          <Tooltip formatter={(value) => [`€${value}`, 'Savings']} />
+          <Tooltip formatter={(value) => [currencyFormatter.format(value), t('reports.charts.tooltipSavings')]} />
           <Line type="monotone" dataKey="savings" stroke="#C56A1A" strokeWidth={3} dot={{ r: 6, fill: '#1F3C88' }} />
         </LineChart>
       </ResponsiveContainer>

--- a/frontend/src/components/charts/StackedBar.jsx
+++ b/frontend/src/components/charts/StackedBar.jsx
@@ -1,15 +1,35 @@
+import { useMemo } from 'react';
 import { Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import { useAppContext } from '../../context/AppContext.jsx';
 
 export default function StackedBar({ data }) {
+  const { t, locale } = useAppContext();
+
+  const localizedData = useMemo(
+    () => data.map((entry) => ({ ...entry, month: t(`reports.months.${entry.month}`) })),
+    [data, t]
+  );
+
+  const currencyFormatter = useMemo(
+    () =>
+      new Intl.NumberFormat(locale, {
+        style: 'currency',
+        currency: 'EUR',
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 0
+      }),
+    [locale]
+  );
+
   return (
     <div className="chart-card">
-      <h3>Culture Stacked Spend</h3>
+      <h3>{t('reports.charts.stackedTitle')}</h3>
       <ResponsiveContainer width="100%" height={280}>
-        <BarChart data={data}>
+        <BarChart data={localizedData}>
           <CartesianGrid strokeDasharray="3 3" vertical={false} />
           <XAxis dataKey="month" tick={{ fill: '#333' }} />
           <YAxis tick={{ fill: '#333' }} />
-          <Tooltip formatter={(value) => [`€${value}`, 'Amount']} />
+          <Tooltip formatter={(value) => [currencyFormatter.format(value), t('reports.charts.tooltipAmount')]} />
           <Bar dataKey="paola" stackId="a" fill="#F7B538" name="Paola" />
           <Bar dataKey="carlo" stackId="a" fill="#6C7A4C" name="Carlo" />
         </BarChart>

--- a/frontend/src/components/layout/TopNav.jsx
+++ b/frontend/src/components/layout/TopNav.jsx
@@ -4,15 +4,15 @@ import LanguageToggle from '../shared/LanguageToggle.jsx';
 import ProfileChips from '../shared/ProfileChips.jsx';
 
 const navLinks = [
-  { to: '/dashboard', label: 'Dashboard' },
-  { to: '/categories', label: 'Categories' },
-  { to: '/reports', label: 'Reports' }
+  { to: '/dashboard', key: 'dashboard' },
+  { to: '/categories', key: 'categories' },
+  { to: '/reports', key: 'reports' }
 ];
 
 export default function TopNav() {
   const location = useLocation();
   const navigate = useNavigate();
-  const { language } = useAppContext();
+  const { language, t } = useAppContext();
 
   const handleLogoKey = (event) => {
     if (event.key === 'Enter' || event.key === ' ') {
@@ -21,7 +21,7 @@ export default function TopNav() {
   };
 
   return (
-    <header className="top-nav" aria-label="Primary navigation">
+    <header className="top-nav" aria-label={t('nav.ariaPrimary')}>
       <div
         className="logo-block"
         onClick={() => navigate('/dashboard')}
@@ -32,10 +32,10 @@ export default function TopNav() {
         <span className="crest" aria-hidden>🌵</span>
         <div className="logo-text">
           <span className="logo-title">Paola &amp; Carlo</span>
-          <span className="logo-subtitle">Fusion Budget</span>
+          <span className="logo-subtitle">{t('nav.logoSubtitle')}</span>
         </div>
       </div>
-      <nav className="nav-links" aria-label="Main pages">
+      <nav className="nav-links" aria-label={t('nav.ariaPages')}>
         {navLinks.map((link) => (
           <NavLink
             key={link.to}
@@ -44,7 +44,7 @@ export default function TopNav() {
               isActive || location.pathname === '/' ? 'nav-link nav-link-active' : 'nav-link'
             }
           >
-            {link.label}
+            {t(`nav.links.${link.key}`)}
           </NavLink>
         ))}
       </nav>

--- a/frontend/src/components/modals/AddEntryModal.jsx
+++ b/frontend/src/components/modals/AddEntryModal.jsx
@@ -10,15 +10,10 @@ const initialForm = {
   split: 50
 };
 
-const categories = [
-  { value: 'groceries', label: 'Groceries' },
-  { value: 'transport', label: 'Transport' },
-  { value: 'housing', label: 'Housing' },
-  { value: 'leisure', label: 'Leisure' }
-];
+const categories = ['groceries', 'transport', 'housing', 'leisure'];
 
 export default function AddEntryModal() {
-  const { modalState, closeModal, setModalTab } = useAppContext();
+  const { modalState, closeModal, setModalTab, t } = useAppContext();
   const [form, setForm] = useState(initialForm);
 
   const handleClose = () => {
@@ -44,8 +39,8 @@ export default function AddEntryModal() {
     <div className="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="entry-modal-title">
       <div className="modal-card">
         <header className="modal-header">
-          <h2 id="entry-modal-title">Registrar Movimiento</h2>
-          <div className="modal-tabs" role="tablist" aria-label="Choose entry type">
+          <h2 id="entry-modal-title">{t('modal.title')}</h2>
+          <div className="modal-tabs" role="tablist" aria-label={t('modal.ariaTabs')}>
             {['income', 'expense'].map((tab) => (
               <button
                 key={tab}
@@ -55,16 +50,16 @@ export default function AddEntryModal() {
                 className={modalState.tab === tab ? 'modal-tab active' : 'modal-tab'}
                 onClick={() => setModalTab(tab)}
               >
-                {tab === 'income' ? 'Registrar Ingreso' : 'Registrar Gasto'}
+                {t(`modal.tabs.${tab}`)}
               </button>
             ))}
           </div>
-          <p className="modal-subtitle">Sombrero &amp; gondola sliders to split contributions.</p>
+          <p className="modal-subtitle">{t('modal.subtitle')}</p>
         </header>
         <form className="modal-form" onSubmit={handleSubmit}>
           <div className="field-grid">
             <label>
-              <span>Monto (€)</span>
+              <span>{t('modal.amount')}</span>
               <input
                 name="amount"
                 type="number"
@@ -76,26 +71,26 @@ export default function AddEntryModal() {
               />
             </label>
             <label>
-              <span>Fecha</span>
+              <span>{t('modal.date')}</span>
               <input name="date" type="date" value={form.date} onChange={handleChange} required />
             </label>
           </div>
           <label>
-            <span>Descripción</span>
+            <span>{t('modal.description')}</span>
             <input name="description" type="text" value={form.description} onChange={handleChange} />
           </label>
           <label>
-            <span>Categoría</span>
+            <span>{t('modal.category')}</span>
             <select name="category" value={form.category} onChange={handleChange}>
               {categories.map((option) => (
-                <option key={option.value} value={option.value}>
-                  {option.label}
+                <option key={option} value={option}>
+                  {t(`modal.categories.${option}`)}
                 </option>
               ))}
             </select>
           </label>
           <label className="slider-field">
-            <span>Repartir entre Paola (sombrero) y Carlo (góndola)</span>
+            <span>{t('modal.split')}</span>
             <input
               type="range"
               min="0"
@@ -111,10 +106,10 @@ export default function AddEntryModal() {
           </label>
           <footer className="modal-actions">
             <PillButton type="submit" variant="primary">
-              {modalState.tab === 'income' ? 'Guardar Ingreso' : 'Guardar Gasto'}
+              {modalState.tab === 'income' ? t('modal.saveIncome') : t('modal.saveExpense')}
             </PillButton>
             <PillButton type="button" variant="ghost" onClick={handleClose}>
-              Cancelar
+              {t('modal.cancel')}
             </PillButton>
           </footer>
         </form>

--- a/frontend/src/components/shared/LanguageToggle.jsx
+++ b/frontend/src/components/shared/LanguageToggle.jsx
@@ -1,4 +1,3 @@
-import { useMemo } from 'react';
 import { useAppContext } from '../../context/AppContext.jsx';
 
 const languages = [
@@ -8,20 +7,12 @@ const languages = [
 ];
 
 export default function LanguageToggle({ current }) {
-  const { toggleLanguage } = useAppContext();
-  const label = useMemo(() => {
-    switch (current) {
-      case 'es':
-        return 'Idioma actual español';
-      case 'it':
-        return 'Lingua attuale italiana';
-      default:
-        return 'Current language English';
-    }
-  }, [current]);
+  const { toggleLanguage, t } = useAppContext();
+  const label = t('languageToggle.current');
+  const groupLabel = t('languageToggle.primaryLabel');
 
   return (
-    <div className="language-toggle" role="group" aria-label={label}>
+    <div className="language-toggle" role="group" aria-label={groupLabel}>
       {languages.map((lang) => (
         <button
           key={lang.code}
@@ -29,6 +20,7 @@ export default function LanguageToggle({ current }) {
           className={lang.code === current ? 'pill active' : 'pill'}
           onClick={() => toggleLanguage(lang.code)}
           aria-pressed={lang.code === current}
+          aria-label={lang.code === current ? label : undefined}
         >
           {lang.label}
         </button>

--- a/frontend/src/components/shared/ProfileChips.jsx
+++ b/frontend/src/components/shared/ProfileChips.jsx
@@ -1,11 +1,15 @@
+import { useAppContext } from '../../context/AppContext.jsx';
+
 const profiles = [
   { name: 'Paola', icon: '🎉', accent: 'mexico' },
   { name: 'Carlo', icon: '☕', accent: 'italy' }
 ];
 
 export default function ProfileChips() {
+  const { t } = useAppContext();
+
   return (
-    <div className="profile-chips" role="group" aria-label="Profiles">
+    <div className="profile-chips" role="group" aria-label={t('common.profilesLabel')}>
       {profiles.map((profile) => (
         <span key={profile.name} className={`profile-chip ${profile.accent}`}>
           <span aria-hidden>{profile.icon}</span>

--- a/frontend/src/context/AppContext.jsx
+++ b/frontend/src/context/AppContext.jsx
@@ -1,26 +1,45 @@
-import { createContext, useContext, useMemo, useState } from 'react';
+import { createContext, useCallback, useContext, useMemo, useState } from 'react';
+import { translations } from '../data/translations.js';
 
 const AppContext = createContext(null);
+
+const localeMap = {
+  es: 'es-ES',
+  it: 'it-IT',
+  en: 'en-US'
+};
 
 export function AppProvider({ children }) {
   const [language, setLanguage] = useState('es');
   const [modalState, setModalState] = useState({ open: false, tab: 'income' });
 
-  const toggleLanguage = (lang) => setLanguage(lang);
-  const openModal = (tab = 'income') => setModalState({ open: true, tab });
-  const closeModal = () => setModalState((prev) => ({ ...prev, open: false }));
-  const setModalTab = (tab) => setModalState((prev) => ({ ...prev, tab }));
+  const toggleLanguage = useCallback((lang) => setLanguage(lang), []);
+  const openModal = useCallback((tab = 'income') => setModalState({ open: true, tab }), []);
+  const closeModal = useCallback(() => setModalState((prev) => ({ ...prev, open: false })), []);
+  const setModalTab = useCallback((tab) => setModalState((prev) => ({ ...prev, tab })), []);
+
+  const locale = localeMap[language] ?? 'en-US';
+  const dictionary = useMemo(() => translations[language], [language]);
+  const t = useCallback(
+    (path) =>
+      path
+        .split('.')
+        .reduce((acc, key) => (acc && typeof acc === 'object' ? acc[key] : undefined), dictionary) ?? path,
+    [dictionary]
+  );
 
   const value = useMemo(
     () => ({
       language,
+      locale,
       toggleLanguage,
       modalState,
       openModal,
       closeModal,
-      setModalTab
+      setModalTab,
+      t
     }),
-    [language, modalState]
+    [language, locale, toggleLanguage, modalState, openModal, closeModal, setModalTab, t]
   );
 
   return <AppContext.Provider value={value}>{children}</AppContext.Provider>;

--- a/frontend/src/data/categories.js
+++ b/frontend/src/data/categories.js
@@ -1,37 +1,24 @@
-export const categoryFilters = [
-  { label: 'All', value: 'all' },
-  { label: 'Mexican', value: 'mexico' },
-  { label: 'Italian', value: 'italy' },
-  { label: 'Fusion', value: 'fusion' }
-];
+export const categoryFilters = ['all', 'mexico', 'italy', 'fusion'];
 
 export const categories = [
   {
-    name: 'Groceries',
+    id: 'groceries',
     subcategories: 6,
-    culture: 'Fusion',
-    tone: 'fusion',
-    description: 'Mercados locales + Mercato Centrale'
+    tone: 'fusion'
   },
   {
-    name: 'Housing',
+    id: 'housing',
     subcategories: 3,
-    culture: 'Italian',
-    tone: 'italy',
-    description: 'Apartamento en Trastevere'
+    tone: 'italy'
   },
   {
-    name: 'Celebrations',
+    id: 'celebrations',
     subcategories: 5,
-    culture: 'Mexican',
-    tone: 'mexico',
-    description: 'Fiestas familiares y festivales'
+    tone: 'mexico'
   },
   {
-    name: 'Travel',
+    id: 'travel',
     subcategories: 4,
-    culture: 'Fusion',
-    tone: 'fusion',
-    description: 'Visitas a familia en CDMX y Roma'
+    tone: 'fusion'
   }
 ];

--- a/frontend/src/data/dashboard.js
+++ b/frontend/src/data/dashboard.js
@@ -1,54 +1,75 @@
 export const kpis = [
-  {
-    label: 'Total Income',
-    value: '€6,200',
-    change: '+8% vs last month',
-    tone: 'warm'
-  },
-  {
-    label: 'Total Expenses',
-    value: '€4,150',
-    change: '-3% vs last month',
-    tone: 'cool'
-  },
-  {
-    label: 'Remaining Budget',
-    value: '€2,050',
-    change: 'Paola 48% / Carlo 52%',
-    tone: 'neutral'
-  }
+  { id: 'totalIncome', value: 6200, tone: 'warm' },
+  { id: 'totalExpenses', value: 4150, tone: 'cool' },
+  { id: 'remainingBudget', value: 2050, tone: 'neutral' }
 ];
 
 export const expenseBreakdown = [
-  { name: 'Groceries', value: 800, fill: '#E94256' },
-  { name: 'Rent', value: 1500, fill: '#1F3C88' },
-  { name: 'Transport', value: 320, fill: '#F7B538' },
-  { name: 'Dining', value: 450, fill: '#2FA36B' },
-  { name: 'Culture', value: 280, fill: '#C56A1A' }
+  { id: 'groceries', value: 800, fill: '#E94256' },
+  { id: 'rent', value: 1500, fill: '#1F3C88' },
+  { id: 'transport', value: 320, fill: '#F7B538' },
+  { id: 'dining', value: 450, fill: '#2FA36B' },
+  { id: 'culture', value: 280, fill: '#C56A1A' }
 ];
 
 export const incomeStreams = [
-  { name: 'Paola Art Studio', paola: 2400, carlo: 400 },
-  { name: 'Carlo Consultancy', paola: 600, carlo: 2600 },
-  { name: 'Shared Rentals', paola: 300, carlo: 600 }
+  { id: 'paolaStudio', paola: 2400, carlo: 400 },
+  { id: 'carloConsultancy', paola: 600, carlo: 2600 },
+  { id: 'sharedRentals', paola: 300, carlo: 600 }
 ];
 
 export const transactions = [
-  { id: 1, label: 'Mercado Roma groceries', amount: '-€120', tag: 'Paola', tone: 'mexico' },
-  { id: 2, label: 'Florence metro passes', amount: '-€45', tag: 'Carlo', tone: 'italy' },
-  { id: 3, label: 'Wedding photography gig', amount: '+€650', tag: 'Paola', tone: 'mexico' },
-  { id: 4, label: 'Espresso bar pop-up', amount: '+€380', tag: 'Carlo', tone: 'italy' }
+  {
+    id: 1,
+    name: 'mercadoGroceries',
+    person: 'Paola',
+    amount: -120,
+    date: '2024-05-12',
+    tone: 'mexico'
+  },
+  {
+    id: 2,
+    name: 'florenceMetro',
+    person: 'Carlo',
+    amount: -45,
+    date: '2024-05-10',
+    tone: 'italy'
+  },
+  {
+    id: 3,
+    name: 'weddingPhotography',
+    person: 'Paola',
+    amount: 650,
+    date: '2024-05-08',
+    tone: 'mexico'
+  },
+  {
+    id: 4,
+    name: 'espressoPopup',
+    person: 'Carlo',
+    amount: 380,
+    date: '2024-05-06',
+    tone: 'italy'
+  },
+  {
+    id: 5,
+    name: 'artSupplies',
+    person: 'Paola',
+    amount: -85,
+    date: '2024-05-03',
+    tone: 'mexico'
+  },
+  {
+    id: 6,
+    name: 'consultingRetainer',
+    person: 'Carlo',
+    amount: 900,
+    date: '2024-05-01',
+    tone: 'italy'
+  }
 ];
 
 export const spotlightItems = [
-  {
-    title: "Paola's Spotlight",
-    description: 'Prepara enchiladas suizas en casa para ahorrar €25 esta semana.',
-    accent: 'mexico'
-  },
-  {
-    title: "Carlo's Spotlight",
-    description: 'Usa el abono mensual del tranvía y ahorra €15 en combustible.',
-    accent: 'italy'
-  }
+  { id: 'paola', accent: 'mexico' },
+  { id: 'carlo', accent: 'italy' }
 ];

--- a/frontend/src/data/reports.js
+++ b/frontend/src/data/reports.js
@@ -3,26 +3,26 @@ export const reportFilters = {
     start: '2024-01-01',
     end: '2024-12-31'
   },
-  categories: ['Housing', 'Groceries', 'Travel']
+  categories: ['housing', 'groceries', 'travel']
 };
 
 export const stackedBarData = [
-  { month: 'Jan', paola: 1200, carlo: 900 },
-  { month: 'Feb', paola: 1150, carlo: 980 },
-  { month: 'Mar', paola: 1400, carlo: 1020 },
-  { month: 'Apr', paola: 1380, carlo: 1110 }
+  { month: 'jan', paola: 1200, carlo: 900 },
+  { month: 'feb', paola: 1150, carlo: 980 },
+  { month: 'mar', paola: 1400, carlo: 1020 },
+  { month: 'apr', paola: 1380, carlo: 1110 }
 ];
 
 export const projectionData = [
-  { month: 'Jan', savings: 450 },
-  { month: 'Feb', savings: 560 },
-  { month: 'Mar', savings: 610 },
-  { month: 'Apr', savings: 720 },
-  { month: 'May', savings: 830 }
+  { month: 'jan', savings: 450 },
+  { month: 'feb', savings: 560 },
+  { month: 'mar', savings: 610 },
+  { month: 'apr', savings: 720 },
+  { month: 'may', savings: 830 }
 ];
 
 export const monthlySummaries = [
-  { month: 'January', income: '€6,050', expenses: '€4,210', savings: '€1,840' },
-  { month: 'February', income: '€6,120', expenses: '€4,050', savings: '€2,070' },
-  { month: 'March', income: '€6,480', expenses: '€4,280', savings: '€2,200' }
+  { month: 'january', income: 6050, expenses: 4210, savings: 1840 },
+  { month: 'february', income: 6120, expenses: 4050, savings: 2070 },
+  { month: 'march', income: 6480, expenses: 4280, savings: 2200 }
 ];

--- a/frontend/src/data/translations.js
+++ b/frontend/src/data/translations.js
@@ -1,0 +1,644 @@
+export const translations = {
+  es: {
+    languageToggle: {
+      current: 'Idioma actual: español',
+      primaryLabel: 'Idioma principal'
+    },
+    common: {
+      amount: 'Monto',
+      date: 'Fecha',
+      person: 'Persona',
+      name: 'Nombre',
+      profilesLabel: 'Perfiles'
+    },
+    login: {
+      heroHeading: 'Bienvenidos / Benvenuti',
+      heroSubtitle: 'Una herramienta vibrante para armonizar los sueños de Paola y Carlo.',
+      accessTitle: 'Accede a tu presupuesto',
+      email: 'Correo electrónico',
+      password: 'Contraseña',
+      submit: 'Ingresar',
+      forgot: '¿Olvidaste tu contraseña?'
+    },
+    nav: {
+      ariaPrimary: 'Navegación principal',
+      ariaPages: 'Páginas principales',
+      logoSubtitle: 'Presupuesto Fusión',
+      links: {
+        dashboard: 'Panel',
+        categories: 'Categorías',
+        reports: 'Informes'
+      }
+    },
+    dashboard: {
+      quickAdd: {
+        title: 'Registro rápido',
+        description: 'Captura ingresos y gastos con toques culturales personalizados.',
+        addIncome: 'Agregar ingreso',
+        addExpense: 'Agregar gasto'
+      },
+      spotlightToggle: 'Cambiar foco cultural',
+      kpis: {
+        totalIncome: {
+          label: 'Ingresos totales',
+          change: '+8% vs. mes anterior'
+        },
+        totalExpenses: {
+          label: 'Gastos totales',
+          change: '-3% vs. mes anterior'
+        },
+        remainingBudget: {
+          label: 'Presupuesto restante',
+          change: 'Paola 48% / Carlo 52%'
+        }
+      },
+      expenseBreakdown: {
+        groceries: 'Supermercado',
+        rent: 'Renta',
+        transport: 'Transporte',
+        dining: 'Comidas',
+        culture: 'Cultura'
+      },
+      incomeStreams: {
+        paolaStudio: 'Estudio de arte de Paola',
+        carloConsultancy: 'Consultoría de Carlo',
+        sharedRentals: 'Alquileres compartidos'
+      },
+      timeline: {
+        title: 'Actividad reciente',
+        headers: {
+          name: 'Movimiento',
+          person: 'Persona',
+          date: 'Fecha',
+          amount: 'Monto'
+        },
+        items: {
+          mercadoGroceries: 'Mercado Roma - despensa semanal',
+          florenceMetro: 'Pases de metro de Florencia',
+          weddingPhotography: 'Sesión fotográfica de boda',
+          espressoPopup: 'Pop-up de espresso artesano',
+          artSupplies: 'Lienzos y pinturas artesanales',
+          consultingRetainer: 'Retenedor de consultoría internacional'
+        }
+      },
+      spotlights: {
+        paola: {
+          title: 'Enfoque de Paola',
+          description: 'Prepara enchiladas suizas en casa para ahorrar €25 esta semana.'
+        },
+        carlo: {
+          title: 'Enfoque de Carlo',
+          description: 'Usa el abono mensual del tranvía y ahorra €15 en combustible.'
+        }
+      },
+      charts: {
+        expenseBreakdown: 'Distribución de gastos',
+        incomeStreams: 'Fuentes de ingreso',
+        tooltipAmount: 'Monto'
+      }
+    },
+    categories: {
+      title: 'Gestión de categorías',
+      subtitle: 'Organiza etiquetas con el ritmo de mariachi y melodías italianas.',
+      filtersLabel: 'Filtros',
+      addCategory: 'Agregar categoría',
+      close: 'Cerrar',
+      form: {
+        name: 'Nombre',
+        accent: 'Acento cultural',
+        save: 'Guardar'
+      },
+      headers: {
+        category: 'Categoría',
+        subcategories: 'Subcategorías',
+        culturalTag: 'Etiqueta cultural',
+        actions: 'Acciones'
+      },
+      actions: {
+        edit: 'Editar',
+        delete: 'Eliminar'
+      },
+      cultureLabels: {
+        mexico: 'Mexicana',
+        italy: 'Italiana',
+        fusion: 'Fusión'
+      },
+      filtersList: {
+        all: 'Todas',
+        mexico: 'Mexicanas',
+        italy: 'Italianas',
+        fusion: 'Fusión'
+      },
+      footer: '🎺 Celebra tus ahorros como mariachi, ☕ saborea cada logro con espresso.',
+      newDescription: 'Nueva categoría cultural',
+      items: {
+        groceries: {
+          name: 'Supermercado',
+          description: 'Mercados locales + Mercato Centrale'
+        },
+        housing: {
+          name: 'Vivienda',
+          description: 'Apartamento en Trastevere'
+        },
+        celebrations: {
+          name: 'Celebraciones',
+          description: 'Fiestas familiares y festivales'
+        },
+        travel: {
+          name: 'Viajes',
+          description: 'Visitas a familia en CDMX y Roma'
+        }
+      }
+    },
+    reports: {
+      title: 'Informes',
+      subtitle: 'Crea historias financieras con subrayados tricolores dinámicos.',
+      filters: {
+        aria: 'Filtros de informe',
+        dateFrom: 'Fecha inicial',
+        dateTo: 'Fecha final'
+      },
+      exportCsv: 'Exportar CSV',
+      exportPdf: 'Exportar PDF',
+      filterCategories: {
+        housing: 'Vivienda',
+        groceries: 'Supermercado',
+        travel: 'Viajes'
+      },
+      charts: {
+        stackedTitle: 'Gasto por cultura',
+        savingsTitle: 'Proyección de ahorros',
+        tooltipAmount: 'Monto',
+        tooltipSavings: 'Ahorros'
+      },
+      summaryTitle: 'Resumen mensual',
+      tableHeaders: {
+        month: 'Mes',
+        income: 'Ingresos',
+        expenses: 'Gastos',
+        savings: 'Ahorros'
+      },
+      months: {
+        jan: 'Ene',
+        feb: 'Feb',
+        mar: 'Mar',
+        apr: 'Abr',
+        may: 'May',
+        january: 'Enero',
+        february: 'Febrero',
+        march: 'Marzo'
+      }
+    },
+    modal: {
+      title: 'Registrar movimiento',
+      tabs: {
+        income: 'Registrar ingreso',
+        expense: 'Registrar gasto'
+      },
+      subtitle: 'Desliza entre sombrero y góndola para dividir aportes.',
+      ariaTabs: 'Elegir tipo de movimiento',
+      amount: 'Monto (€)',
+      date: 'Fecha',
+      description: 'Descripción',
+      category: 'Categoría',
+      split: 'Repartir entre Paola (sombrero) y Carlo (góndola)',
+      saveIncome: 'Guardar ingreso',
+      saveExpense: 'Guardar gasto',
+      cancel: 'Cancelar',
+      categories: {
+        groceries: 'Supermercado',
+        transport: 'Transporte',
+        housing: 'Vivienda',
+        leisure: 'Ocio'
+      }
+    }
+  },
+  it: {
+    languageToggle: {
+      current: 'Lingua attuale: italiano',
+      primaryLabel: 'Lingua principale'
+    },
+    common: {
+      amount: 'Importo',
+      date: 'Data',
+      person: 'Persona',
+      name: 'Nome',
+      profilesLabel: 'Profili'
+    },
+    login: {
+      heroHeading: 'Benvenuti / Bienvenidos',
+      heroSubtitle: 'Uno strumento vibrante per armonizzare i sogni di Paola e Carlo.',
+      accessTitle: 'Accedi al tuo budget',
+      email: 'Email',
+      password: 'Password',
+      submit: 'Accedi',
+      forgot: 'Password dimenticata?'
+    },
+    nav: {
+      ariaPrimary: 'Navigazione principale',
+      ariaPages: 'Pagine principali',
+      logoSubtitle: 'Bilancio Fusion',
+      links: {
+        dashboard: 'Cruscotto',
+        categories: 'Categorie',
+        reports: 'Report'
+      }
+    },
+    dashboard: {
+      quickAdd: {
+        title: 'Aggiunta rapida',
+        description: 'Registra entrate e uscite con tocchi culturali personalizzati.',
+        addIncome: 'Aggiungi entrata',
+        addExpense: 'Aggiungi spesa'
+      },
+      spotlightToggle: 'Scambia il focus culturale',
+      kpis: {
+        totalIncome: {
+          label: 'Entrate totali',
+          change: '+8% vs. mese precedente'
+        },
+        totalExpenses: {
+          label: 'Spese totali',
+          change: '-3% vs. mese precedente'
+        },
+        remainingBudget: {
+          label: 'Budget restante',
+          change: 'Paola 48% / Carlo 52%'
+        }
+      },
+      expenseBreakdown: {
+        groceries: 'Spesa',
+        rent: 'Affitto',
+        transport: 'Trasporti',
+        dining: 'Ristoranti',
+        culture: 'Cultura'
+      },
+      incomeStreams: {
+        paolaStudio: 'Studio d’arte di Paola',
+        carloConsultancy: 'Consulenza di Carlo',
+        sharedRentals: 'Affitti condivisi'
+      },
+      timeline: {
+        title: 'Attività recente',
+        headers: {
+          name: 'Movimento',
+          person: 'Persona',
+          date: 'Data',
+          amount: 'Importo'
+        },
+        items: {
+          mercadoGroceries: 'Spesa settimanale al Mercado Roma',
+          florenceMetro: 'Abbonamenti metro Firenze',
+          weddingPhotography: 'Servizio fotografico di nozze',
+          espressoPopup: 'Pop-up di espresso artigianale',
+          artSupplies: 'Tele e colori artigianali',
+          consultingRetainer: 'Anticipo consulenza internazionale'
+        }
+      },
+      spotlights: {
+        paola: {
+          title: 'Focus di Paola',
+          description: 'Prepara enchiladas suizas a casa e risparmia €25 questa settimana.'
+        },
+        carlo: {
+          title: 'Focus di Carlo',
+          description: 'Usa l’abbonamento mensile del tram e risparmia €15 di carburante.'
+        }
+      },
+      charts: {
+        expenseBreakdown: 'Ripartizione delle spese',
+        incomeStreams: 'Fonti di entrata',
+        tooltipAmount: 'Importo'
+      }
+    },
+    categories: {
+      title: 'Gestione categorie',
+      subtitle: 'Organizza le etichette al ritmo del mariachi e con melodie italiane.',
+      filtersLabel: 'Filtri',
+      addCategory: 'Aggiungi categoria',
+      close: 'Chiudi',
+      form: {
+        name: 'Nome',
+        accent: 'Accento culturale',
+        save: 'Salva'
+      },
+      headers: {
+        category: 'Categoria',
+        subcategories: 'Sottocategorie',
+        culturalTag: 'Tag culturale',
+        actions: 'Azioni'
+      },
+      actions: {
+        edit: 'Modifica',
+        delete: 'Elimina'
+      },
+      cultureLabels: {
+        mexico: 'Messicana',
+        italy: 'Italiana',
+        fusion: 'Fusion'
+      },
+      filtersList: {
+        all: 'Tutte',
+        mexico: 'Messicane',
+        italy: 'Italiane',
+        fusion: 'Fusion'
+      },
+      footer: '🎺 Festeggia i risparmi come un mariachi, ☕ assapora ogni traguardo con un espresso.',
+      newDescription: 'Nuova categoria culturale',
+      items: {
+        groceries: {
+          name: 'Spesa',
+          description: 'Mercati locali + Mercato Centrale'
+        },
+        housing: {
+          name: 'Abitazione',
+          description: 'Appartamento a Trastevere'
+        },
+        celebrations: {
+          name: 'Celebrazioni',
+          description: 'Feste di famiglia e festival'
+        },
+        travel: {
+          name: 'Viaggi',
+          description: 'Visite a famiglia a Città del Messico e Roma'
+        }
+      }
+    },
+    reports: {
+      title: 'Report',
+      subtitle: 'Crea storie finanziarie con sottolineature tricolori dinamiche.',
+      filters: {
+        aria: 'Filtri dei report',
+        dateFrom: 'Data inizio',
+        dateTo: 'Data fine'
+      },
+      exportCsv: 'Esporta CSV',
+      exportPdf: 'Esporta PDF',
+      filterCategories: {
+        housing: 'Abitazione',
+        groceries: 'Spesa',
+        travel: 'Viaggi'
+      },
+      charts: {
+        stackedTitle: 'Spesa per cultura',
+        savingsTitle: 'Proiezione risparmi',
+        tooltipAmount: 'Importo',
+        tooltipSavings: 'Risparmi'
+      },
+      summaryTitle: 'Riepilogo mensile',
+      tableHeaders: {
+        month: 'Mese',
+        income: 'Entrate',
+        expenses: 'Spese',
+        savings: 'Risparmi'
+      },
+      months: {
+        jan: 'Gen',
+        feb: 'Feb',
+        mar: 'Mar',
+        apr: 'Apr',
+        may: 'Mag',
+        january: 'Gennaio',
+        february: 'Febbraio',
+        march: 'Marzo'
+      }
+    },
+    modal: {
+      title: 'Registrare movimento',
+      tabs: {
+        income: 'Registra entrata',
+        expense: 'Registra spesa'
+      },
+      subtitle: 'Fai scorrere tra sombrero e gondola per dividere i contributi.',
+      ariaTabs: 'Scegli il tipo di movimento',
+      amount: 'Importo (€)',
+      date: 'Data',
+      description: 'Descrizione',
+      category: 'Categoria',
+      split: 'Dividi tra Paola (sombrero) e Carlo (gondola)',
+      saveIncome: 'Salva entrata',
+      saveExpense: 'Salva spesa',
+      cancel: 'Annulla',
+      categories: {
+        groceries: 'Spesa',
+        transport: 'Trasporti',
+        housing: 'Abitazione',
+        leisure: 'Tempo libero'
+      }
+    }
+  },
+  en: {
+    languageToggle: {
+      current: 'Current language: English',
+      primaryLabel: 'Primary language'
+    },
+    common: {
+      amount: 'Amount',
+      date: 'Date',
+      person: 'Person',
+      name: 'Name',
+      profilesLabel: 'Profiles'
+    },
+    login: {
+      heroHeading: 'Welcome',
+      heroSubtitle: 'A vibrant tool to harmonize Paola and Carlo’s dreams.',
+      accessTitle: 'Access your budget',
+      email: 'Email',
+      password: 'Password',
+      submit: 'Sign in',
+      forgot: 'Forgot password?'
+    },
+    nav: {
+      ariaPrimary: 'Primary navigation',
+      ariaPages: 'Main pages',
+      logoSubtitle: 'Fusion Budget',
+      links: {
+        dashboard: 'Dashboard',
+        categories: 'Categories',
+        reports: 'Reports'
+      }
+    },
+    dashboard: {
+      quickAdd: {
+        title: 'Quick add',
+        description: 'Capture income and expenses with personalized cultural flair.',
+        addIncome: 'Add income',
+        addExpense: 'Add expense'
+      },
+      spotlightToggle: 'Swap cultural spotlight',
+      kpis: {
+        totalIncome: {
+          label: 'Total income',
+          change: '+8% vs. last month'
+        },
+        totalExpenses: {
+          label: 'Total expenses',
+          change: '-3% vs. last month'
+        },
+        remainingBudget: {
+          label: 'Remaining budget',
+          change: 'Paola 48% / Carlo 52%'
+        }
+      },
+      expenseBreakdown: {
+        groceries: 'Groceries',
+        rent: 'Rent',
+        transport: 'Transport',
+        dining: 'Dining',
+        culture: 'Culture'
+      },
+      incomeStreams: {
+        paolaStudio: 'Paola art studio',
+        carloConsultancy: 'Carlo consultancy',
+        sharedRentals: 'Shared rentals'
+      },
+      timeline: {
+        title: 'Recent activity',
+        headers: {
+          name: 'Name',
+          person: 'Person',
+          date: 'Date',
+          amount: 'Amount'
+        },
+        items: {
+          mercadoGroceries: 'Mercado Roma groceries',
+          florenceMetro: 'Florence metro passes',
+          weddingPhotography: 'Wedding photography gig',
+          espressoPopup: 'Espresso bar pop-up',
+          artSupplies: 'Artisan canvas & paints',
+          consultingRetainer: 'Consulting retainer invoice'
+        }
+      },
+      spotlights: {
+        paola: {
+          title: 'Paola’s spotlight',
+          description: 'Prepare enchiladas suizas at home to save €25 this week.'
+        },
+        carlo: {
+          title: 'Carlo’s spotlight',
+          description: 'Use the monthly tram pass and save €15 on fuel.'
+        }
+      },
+      charts: {
+        expenseBreakdown: 'Expense breakdown',
+        incomeStreams: 'Income streams',
+        tooltipAmount: 'Amount'
+      }
+    },
+    categories: {
+      title: 'Category management',
+      subtitle: 'Organize labels with mariachi rhythm and Italian melodies.',
+      filtersLabel: 'Filters',
+      addCategory: 'Add category',
+      close: 'Close',
+      form: {
+        name: 'Name',
+        accent: 'Cultural accent',
+        save: 'Save'
+      },
+      headers: {
+        category: 'Category',
+        subcategories: 'Subcategories',
+        culturalTag: 'Cultural tag',
+        actions: 'Actions'
+      },
+      actions: {
+        edit: 'Edit',
+        delete: 'Delete'
+      },
+      cultureLabels: {
+        mexico: 'Mexican',
+        italy: 'Italian',
+        fusion: 'Fusion'
+      },
+      filtersList: {
+        all: 'All',
+        mexico: 'Mexican',
+        italy: 'Italian',
+        fusion: 'Fusion'
+      },
+      footer: '🎺 Celebrate savings like mariachi, ☕ savor each win with espresso.',
+      newDescription: 'New cultural category',
+      items: {
+        groceries: {
+          name: 'Groceries',
+          description: 'Local markets + Mercato Centrale'
+        },
+        housing: {
+          name: 'Housing',
+          description: 'Apartment in Trastevere'
+        },
+        celebrations: {
+          name: 'Celebrations',
+          description: 'Family fiestas and festivals'
+        },
+        travel: {
+          name: 'Travel',
+          description: 'Trips to family in CDMX and Rome'
+        }
+      }
+    },
+    reports: {
+      title: 'Reports',
+      subtitle: 'Craft financial stories with dynamic tricolour highlights.',
+      filters: {
+        aria: 'Report filters',
+        dateFrom: 'Date from',
+        dateTo: 'Date to'
+      },
+      exportCsv: 'Export CSV',
+      exportPdf: 'Export PDF',
+      filterCategories: {
+        housing: 'Housing',
+        groceries: 'Groceries',
+        travel: 'Travel'
+      },
+      charts: {
+        stackedTitle: 'Culture stacked spend',
+        savingsTitle: 'Savings projection',
+        tooltipAmount: 'Amount',
+        tooltipSavings: 'Savings'
+      },
+      summaryTitle: 'Monthly summaries',
+      tableHeaders: {
+        month: 'Month',
+        income: 'Income',
+        expenses: 'Expenses',
+        savings: 'Savings'
+      },
+      months: {
+        jan: 'Jan',
+        feb: 'Feb',
+        mar: 'Mar',
+        apr: 'Apr',
+        may: 'May',
+        january: 'January',
+        february: 'February',
+        march: 'March'
+      }
+    },
+    modal: {
+      title: 'Record entry',
+      tabs: {
+        income: 'Record income',
+        expense: 'Record expense'
+      },
+      subtitle: 'Slide between sombrero and gondola to split contributions.',
+      ariaTabs: 'Choose entry type',
+      amount: 'Amount (€)',
+      date: 'Date',
+      description: 'Description',
+      category: 'Category',
+      split: 'Split between Paola (sombrero) and Carlo (gondola)',
+      saveIncome: 'Save income',
+      saveExpense: 'Save expense',
+      cancel: 'Cancel',
+      categories: {
+        groceries: 'Groceries',
+        transport: 'Transport',
+        housing: 'Housing',
+        leisure: 'Leisure'
+      }
+    }
+  }
+};

--- a/frontend/src/pages/CategoryPage.jsx
+++ b/frontend/src/pages/CategoryPage.jsx
@@ -1,8 +1,10 @@
 import { useMemo, useState } from 'react';
 import PillButton from '../components/shared/PillButton.jsx';
 import { categories as initialCategories, categoryFilters } from '../data/categories.js';
+import { useAppContext } from '../context/AppContext.jsx';
 
 export default function CategoryPage() {
+  const { t } = useAppContext();
   const [activeFilter, setActiveFilter] = useState('all');
   const [items, setItems] = useState(initialCategories);
   const [showForm, setShowForm] = useState(false);
@@ -18,7 +20,13 @@ export default function CategoryPage() {
     evt.preventDefault();
     setItems((prev) => [
       ...prev,
-      { name, subcategories: 0, culture: tone === 'mexico' ? 'Mexican' : tone === 'italy' ? 'Italian' : 'Fusion', tone, description: 'New cultural category' }
+      {
+        id: `custom-${Date.now()}`,
+        name,
+        subcategories: 0,
+        tone,
+        descriptionKey: 'categories.newDescription'
+      }
     ]);
     setName('');
     setTone('fusion');
@@ -28,76 +36,90 @@ export default function CategoryPage() {
   return (
     <div className="category-page">
       <header className="page-header">
-        <h1>Category Management</h1>
-        <p>Organiza etiquetas con el ritmo de mariachi y melodías italianas.</p>
+        <h1>{t('categories.title')}</h1>
+        <p>{t('categories.subtitle')}</p>
       </header>
       <div className="category-layout">
         <aside className="category-sidebar">
           <div className="filter-group">
-            <h2>Filters</h2>
+            <h2>{t('categories.filtersLabel')}</h2>
             {categoryFilters.map((filter) => (
               <button
-                key={filter.value}
+                key={filter}
                 type="button"
-                className={filter.value === activeFilter ? 'filter-pill active' : 'filter-pill'}
-                onClick={() => setActiveFilter(filter.value)}
+                className={filter === activeFilter ? 'filter-pill active' : 'filter-pill'}
+                onClick={() => setActiveFilter(filter)}
               >
-                {filter.label}
+                {t(`categories.filtersList.${filter}`)}
               </button>
             ))}
           </div>
           <PillButton variant="outline" onClick={() => setShowForm((state) => !state)}>
-            {showForm ? 'Close' : 'Add Category'}
+            {showForm ? t('categories.close') : t('categories.addCategory')}
           </PillButton>
           {showForm && (
             <form className="category-form" onSubmit={handleAdd}>
               <label>
-                <span>Name</span>
+                <span>{t('categories.form.name')}</span>
                 <input value={name} onChange={(evt) => setName(evt.target.value)} required />
               </label>
               <label>
-                <span>Cultural Accent</span>
+                <span>{t('categories.form.accent')}</span>
                 <select value={tone} onChange={(evt) => setTone(evt.target.value)}>
-                  <option value="mexico">Mexican</option>
-                  <option value="italy">Italian</option>
-                  <option value="fusion">Fusion</option>
+                  <option value="mexico">{t('categories.cultureLabels.mexico')}</option>
+                  <option value="italy">{t('categories.cultureLabels.italy')}</option>
+                  <option value="fusion">{t('categories.cultureLabels.fusion')}</option>
                 </select>
               </label>
-              <PillButton type="submit">Save</PillButton>
+              <PillButton type="submit">{t('categories.form.save')}</PillButton>
             </form>
           )}
         </aside>
         <section className="category-content">
-          <div className="category-table" role="table">
+          <div className="category-table" role="table" aria-label={t('categories.title')}>
             <div className="category-row header" role="row">
-              <span role="columnheader">Category</span>
-              <span role="columnheader">Subcategories</span>
-              <span role="columnheader">Cultural Tag</span>
-              <span role="columnheader">Actions</span>
+              <span role="columnheader">{t('categories.headers.category')}</span>
+              <span role="columnheader">{t('categories.headers.subcategories')}</span>
+              <span role="columnheader">{t('categories.headers.culturalTag')}</span>
+              <span role="columnheader">{t('categories.headers.actions')}</span>
             </div>
-            {filtered.map((item) => (
-              <div key={item.name} className={`category-row ${item.tone}`} role="row">
-                <span role="cell">
-                  <strong>{item.name}</strong>
-                  <small>{item.description}</small>
-                </span>
-                <span role="cell">{item.subcategories}</span>
-                <span role="cell" className="category-tag">
-                  {item.culture}
-                </span>
-                <span role="cell" className="row-actions">
-                  <button type="button" className="icon-button" aria-label={`Edit ${item.name}`}>
-                    🎨
-                  </button>
-                  <button type="button" className="icon-button" aria-label={`Delete ${item.name}`}>
-                    🏛️
-                  </button>
-                </span>
-              </div>
-            ))}
+            {filtered.map((item) => {
+              const displayName = item.name ?? t(`categories.items.${item.id}.name`);
+              const displayDescription =
+                item.description ??
+                (item.descriptionKey ? t(item.descriptionKey) : t(`categories.items.${item.id}.description`));
+              return (
+                <div key={item.id ?? item.name} className={`category-row ${item.tone}`} role="row">
+                  <span role="cell">
+                    <strong>{displayName}</strong>
+                    <small>{displayDescription}</small>
+                  </span>
+                  <span role="cell">{item.subcategories}</span>
+                  <span role="cell" className="category-tag">
+                    {t(`categories.cultureLabels.${item.tone}`)}
+                  </span>
+                  <span role="cell" className="row-actions">
+                    <button
+                      type="button"
+                      className="icon-button"
+                      aria-label={`${t('categories.actions.edit')} ${displayName}`}
+                    >
+                      🎨
+                    </button>
+                    <button
+                      type="button"
+                      className="icon-button"
+                      aria-label={`${t('categories.actions.delete')} ${displayName}`}
+                    >
+                      🏛️
+                    </button>
+                  </span>
+                </div>
+              );
+            })}
           </div>
           <footer className="category-footer">
-            <p>🎺 Celebra tus ahorros como mariachi, ☕ saborea cada logro con espresso.</p>
+            <p>{t('categories.footer')}</p>
           </footer>
         </section>
       </div>

--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -6,16 +6,40 @@ import TimelineCard from '../components/cards/TimelineCard.jsx';
 import ExpenseDonut from '../components/charts/ExpenseDonut.jsx';
 import IncomeStreamsChart from '../components/charts/IncomeStreamsChart.jsx';
 import { expenseBreakdown, incomeStreams, kpis, spotlightItems, transactions } from '../data/dashboard.js';
+import { useAppContext } from '../context/AppContext.jsx';
 
 export default function DashboardPage() {
+  const { t, locale } = useAppContext();
   const [spotlightIndex, setSpotlightIndex] = useState(0);
   const spotlight = useMemo(() => spotlightItems[spotlightIndex], [spotlightIndex]);
+
+  const currencyFormatter = useMemo(
+    () =>
+      new Intl.NumberFormat(locale, {
+        style: 'currency',
+        currency: 'EUR',
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 0
+      }),
+    [locale]
+  );
+
+  const localizedKpis = useMemo(
+    () =>
+      kpis.map((item) => ({
+        ...item,
+        label: t(`dashboard.kpis.${item.id}.label`),
+        change: t(`dashboard.kpis.${item.id}.change`),
+        value: currencyFormatter.format(item.value)
+      })),
+    [currencyFormatter, t]
+  );
 
   return (
     <div className="dashboard-page">
       <section className="kpi-strip">
-        {kpis.map((kpi) => (
-          <KpiCard key={kpi.label} {...kpi} />
+        {localizedKpis.map((kpi) => (
+          <KpiCard key={kpi.id} {...kpi} />
         ))}
       </section>
       <div className="dashboard-grid">
@@ -24,7 +48,7 @@ export default function DashboardPage() {
           <QuickAddCard />
           <div className="spotlight-toggle">
             <button type="button" onClick={() => setSpotlightIndex((index) => (index === 0 ? 1 : 0))}>
-              Swap Spotlight
+              {t('dashboard.spotlightToggle')}
             </button>
           </div>
         </div>

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -4,7 +4,7 @@ import { useAppContext } from '../context/AppContext.jsx';
 
 export default function LoginPage() {
   const navigate = useNavigate();
-  const { toggleLanguage, language } = useAppContext();
+  const { toggleLanguage, language, t } = useAppContext();
 
   const handleSubmit = (evt) => {
     evt.preventDefault();
@@ -16,17 +16,16 @@ export default function LoginPage() {
       <div className="hero-background" aria-hidden />
       <div className="login-content">
         <section className="hero-copy">
-          <h1>
-            <span>Bienvenidos</span> / <span>Benvenuti</span>
-          </h1>
-          <p>Una herramienta vibrante para armonizar los sueños de Paola y Carlo.</p>
-          <div className="language-pill-group" role="group" aria-label="Idioma principal">
+          <h1>{t('login.heroHeading')}</h1>
+          <p>{t('login.heroSubtitle')}</p>
+          <div className="language-pill-group" role="group" aria-label={t('languageToggle.primaryLabel')}>
             {['es', 'it', 'en'].map((code) => (
               <button
                 key={code}
                 type="button"
                 className={code === language ? 'hero-pill active' : 'hero-pill'}
                 onClick={() => toggleLanguage(code)}
+                aria-pressed={code === language}
               >
                 {code.toUpperCase()}
               </button>
@@ -34,20 +33,20 @@ export default function LoginPage() {
           </div>
         </section>
         <section className="login-card" aria-labelledby="login-title">
-          <h2 id="login-title">Access Your Budget</h2>
+          <h2 id="login-title">{t('login.accessTitle')}</h2>
           <form onSubmit={handleSubmit} className="login-form">
             <label>
-              <span>Email</span>
+              <span>{t('login.email')}</span>
               <input type="email" name="email" placeholder="paola.carlo@email.com" required />
             </label>
             <label>
-              <span>Password</span>
+              <span>{t('login.password')}</span>
               <input type="password" name="password" required />
             </label>
             <PillButton type="submit" className="login-submit">
-              Entrar / Accedi
+              {t('login.submit')}
             </PillButton>
-            <a className="forgot-link" href="#">Forgot Password?</a>
+            <a className="forgot-link" href="#">{t('login.forgot')}</a>
           </form>
         </section>
       </div>

--- a/frontend/src/pages/ReportsPage.jsx
+++ b/frontend/src/pages/ReportsPage.jsx
@@ -1,59 +1,74 @@
+import { useMemo } from 'react';
 import StackedBar from '../components/charts/StackedBar.jsx';
 import SavingsProjectionChart from '../components/charts/SavingsProjectionChart.jsx';
 import PillButton from '../components/shared/PillButton.jsx';
 import { monthlySummaries, projectionData, reportFilters, stackedBarData } from '../data/reports.js';
+import { useAppContext } from '../context/AppContext.jsx';
 
 export default function ReportsPage() {
+  const { t, locale } = useAppContext();
+
+  const currencyFormatter = useMemo(
+    () =>
+      new Intl.NumberFormat(locale, {
+        style: 'currency',
+        currency: 'EUR',
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 0
+      }),
+    [locale]
+  );
+
   return (
     <div className="reports-page">
       <header className="page-header">
-        <h1>Reports / Reportes / Rapporti</h1>
-        <p>Crea historias financieras con subrayados tricolores dinámicos.</p>
+        <h1>{t('reports.title')}</h1>
+        <p>{t('reports.subtitle')}</p>
       </header>
-      <section className="reports-filter-bar" aria-label="Report filters">
+      <section className="reports-filter-bar" aria-label={t('reports.filters.aria')}>
         <div className="filter-field">
           <label>
-            <span>Date From</span>
+            <span>{t('reports.filters.dateFrom')}</span>
             <input type="date" defaultValue={reportFilters.range.start} />
           </label>
           <label>
-            <span>Date To</span>
+            <span>{t('reports.filters.dateTo')}</span>
             <input type="date" defaultValue={reportFilters.range.end} />
           </label>
         </div>
         <div className="filter-chips">
           {reportFilters.categories.map((category) => (
             <span key={category} className="chip">
-              {category}
+              {t(`reports.filterCategories.${category}`)}
             </span>
           ))}
         </div>
         <div className="export-actions">
-          <PillButton variant="secondary">Export CSV</PillButton>
-          <PillButton variant="outline">Export PDF</PillButton>
+          <PillButton variant="secondary">{t('reports.exportCsv')}</PillButton>
+          <PillButton variant="outline">{t('reports.exportPdf')}</PillButton>
         </div>
       </section>
       <div className="reports-grid">
         <StackedBar data={stackedBarData} />
         <SavingsProjectionChart data={projectionData} />
-        <section className="summary-table" aria-label="Monthly summaries">
-          <h3>Monthly Summaries</h3>
+        <section className="summary-table" aria-label={t('reports.summaryTitle')}>
+          <h3>{t('reports.summaryTitle')}</h3>
           <table>
             <thead>
               <tr>
-                <th>Month</th>
-                <th>Income</th>
-                <th>Expenses</th>
-                <th>Savings</th>
+                <th>{t('reports.tableHeaders.month')}</th>
+                <th>{t('reports.tableHeaders.income')}</th>
+                <th>{t('reports.tableHeaders.expenses')}</th>
+                <th>{t('reports.tableHeaders.savings')}</th>
               </tr>
             </thead>
             <tbody>
               {monthlySummaries.map((row) => (
                 <tr key={row.month}>
-                  <td>{row.month}</td>
-                  <td>{row.income}</td>
-                  <td>{row.expenses}</td>
-                  <td>{row.savings}</td>
+                  <td>{t(`reports.months.${row.month}`)}</td>
+                  <td>{currencyFormatter.format(row.income)}</td>
+                  <td>{currencyFormatter.format(row.expenses)}</td>
+                  <td>{currencyFormatter.format(row.savings)}</td>
                 </tr>
               ))}
             </tbody>

--- a/frontend/src/styles/theme.css
+++ b/frontend/src/styles/theme.css
@@ -451,43 +451,70 @@ body {
   box-shadow: var(--shadow-soft);
 }
 
-.timeline-card ul {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: grid;
-  gap: 1rem;
+.timeline-table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0 0.5rem;
+  font-size: 0.85rem;
 }
 
-.timeline-card li {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 1rem;
-  border-radius: var(--radius-sm);
+.timeline-table th,
+.timeline-table td {
+  padding: 0.6rem 0.75rem;
+}
+
+.timeline-table th {
+  text-align: left;
+  font-weight: 600;
+  color: var(--text-600);
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.timeline-table tbody tr {
+  background: transparent;
+}
+
+.timeline-table tbody td {
   background: var(--surface-200);
+  font-size: 0.9em;
 }
 
-.timeline-card li.mexico {
-  border-left: 5px solid var(--fiesta-red);
+.timeline-table tbody td:first-child {
+  border-top-left-radius: var(--radius-sm);
+  border-bottom-left-radius: var(--radius-sm);
+  border-left: 4px solid transparent;
 }
 
-.timeline-card li.italy {
-  border-left: 5px solid var(--mediterranean-navy);
+.timeline-table tbody td:last-child {
+  border-top-right-radius: var(--radius-sm);
+  border-bottom-right-radius: var(--radius-sm);
 }
 
-.tx-tag {
-  display: inline-block;
-  margin-top: 0.35rem;
-  padding: 0.2rem 0.6rem;
-  border-radius: 999px;
-  background: white;
-  font-size: 0.75rem;
+.timeline-row.mexico td:first-child {
+  border-left-color: var(--fiesta-red);
+}
+
+.timeline-row.italy td:first-child {
+  border-left-color: var(--mediterranean-navy);
+}
+
+.align-right {
+  text-align: right;
 }
 
 .tx-amount {
   font-weight: 700;
   font-family: var(--font-heading);
+}
+
+.tx-amount.positive {
+  color: var(--mediterranean-navy);
+}
+
+.tx-amount.negative {
+  color: var(--fiesta-red);
 }
 
 .category-layout {


### PR DESCRIPTION
## Summary
- introduce a translations map and context helpers so the active language controls UI copy across the app
- wire navigation, login, dashboard widgets, categories, reports, and the entry modal to translated strings for Spanish, Italian, and English
- reshape recent activity data into a denser table view with additional metadata and updated styling

## Testing
- npm install *(fails: npm registry access is forbidden in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6683bdedc832cb85cd9789ec6e19f