### PR TITLE
Add Express backend scaffolding

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,8 @@
+PORT=4000
+CORS_ORIGIN=http://localhost:5173
+DB_HOST=localhost
+DB_PORT=3306
+DB_USER=root
+DB_PASSWORD=secret
+DB_NAME=budget_tracker
+USE_IN_MEMORY_DB=false

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,99 @@
+# Budget Tracker Backend
+
+This directory contains the Express + TypeScript backend for the Budget Tracker application. The service exposes a REST API for managing users' incomes, expenses, categories, and subcategories. The API can run against a MySQL database (recommended for production) or fall back to an in-memory data store for local prototyping.
+
+## Getting Started
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Copy the example environment file and adjust the values to match your setup:
+   ```bash
+   cp .env.example .env
+   ```
+3. Start the development server with hot reloading:
+   ```bash
+   npm run dev
+   ```
+
+The API listens on `http://localhost:4000` by default.
+
+### In-memory mode
+
+If you do not have a MySQL database available, set `USE_IN_MEMORY_DB=true` in the `.env` file. The service will boot with seeded demo data that lives only for the lifetime of the process.
+
+### Production build
+
+To produce a compiled build, run:
+
+```bash
+npm run build
+npm start
+```
+
+## API Overview
+
+| Method | Endpoint | Description |
+| ------ | -------- | ----------- |
+| GET    | `/api/health` | Health check endpoint. |
+| GET    | `/api/incomes` | Retrieve all income entries. |
+| POST   | `/api/incomes` | Create a new income entry. |
+| GET    | `/api/expenses` | Retrieve all expense entries (with categories & subcategories). |
+| POST   | `/api/expenses` | Create a new expense entry. |
+| GET    | `/api/categories` | Retrieve categories with their subcategories. |
+| POST   | `/api/categories` | Create a new top-level category. |
+| POST   | `/api/categories/:categoryId/subcategories` | Create a subcategory under the specified category. |
+
+All POST endpoints expect JSON bodies; validation errors return HTTP 400 with details. Server errors return HTTP 500 with a descriptive message.
+
+## Database schema
+
+The MySQL implementation expects the following tables (aligned with the requirements document):
+
+```sql
+CREATE TABLE users (
+  user_id INT AUTO_INCREMENT PRIMARY KEY,
+  username VARCHAR(50) NOT NULL,
+  password_hash VARCHAR(255) NOT NULL,
+  email VARCHAR(120) NOT NULL,
+  role ENUM('admin', 'user') DEFAULT 'user'
+);
+
+CREATE TABLE categories (
+  category_id INT AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(100) NOT NULL
+);
+
+CREATE TABLE subcategories (
+  subcategory_id INT AUTO_INCREMENT PRIMARY KEY,
+  category_id INT NOT NULL,
+  name VARCHAR(100) NOT NULL,
+  FOREIGN KEY (category_id) REFERENCES categories(category_id)
+);
+
+CREATE TABLE incomes (
+  income_id INT AUTO_INCREMENT PRIMARY KEY,
+  user_id INT NOT NULL,
+  amount DECIMAL(12,2) NOT NULL,
+  date DATE NOT NULL,
+  source VARCHAR(120),
+  recurring TINYINT(1) DEFAULT 0,
+  FOREIGN KEY (user_id) REFERENCES users(user_id)
+);
+
+CREATE TABLE expenses (
+  expense_id INT AUTO_INCREMENT PRIMARY KEY,
+  user_id INT NOT NULL,
+  amount DECIMAL(12,2) NOT NULL,
+  date DATE NOT NULL,
+  description VARCHAR(255),
+  category_id INT NOT NULL,
+  subcategory_id INT,
+  FOREIGN KEY (user_id) REFERENCES users(user_id),
+  FOREIGN KEY (category_id) REFERENCES categories(category_id),
+  FOREIGN KEY (subcategory_id) REFERENCES subcategories(subcategory_id)
+);
+```
+
+These definitions can be adjusted to suit your production environment.

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "budget-tracker-backend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/server.ts",
+    "build": "tsc",
+    "start": "node dist/server.js"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "mysql2": "^3.9.7",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.12.12",
+    "tsx": "^4.7.3",
+    "typescript": "^5.4.5"
+  }
+}

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,0 +1,29 @@
+import cors from "cors";
+import express from "express";
+import routes from "./routes/index.js";
+import { env } from "./config/env.js";
+
+const app = express();
+
+app.use(express.json());
+app.use(
+  cors({
+    origin: env.corsOrigin ?? true
+  })
+);
+
+app.get("/", (_req, res) => {
+  res.json({
+    name: "Budget Tracker API",
+    documentation: "Refer to backend/README.md for endpoint details."
+  });
+});
+
+app.use("/api", routes);
+
+app.use((err: Error, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+  console.error(err);
+  res.status(500).json({ message: "Unexpected server error" });
+});
+
+export default app;

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -1,0 +1,47 @@
+import dotenv from "dotenv";
+import { z } from "zod";
+
+dotenv.config();
+
+const envSchema = z.object({
+  PORT: z.string().transform(Number).default("4000"),
+  CORS_ORIGIN: z.string().optional(),
+  DB_HOST: z.string().optional(),
+  DB_PORT: z
+    .string()
+    .transform((value) => Number(value))
+    .optional(),
+  DB_USER: z.string().optional(),
+  DB_PASSWORD: z.string().optional(),
+  DB_NAME: z.string().optional(),
+  USE_IN_MEMORY_DB: z
+    .string()
+    .transform((value) => value.toLowerCase() === "true")
+    .default("false")
+});
+
+const rawEnv = envSchema.parse({
+  PORT: process.env.PORT ?? "4000",
+  CORS_ORIGIN: process.env.CORS_ORIGIN,
+  DB_HOST: process.env.DB_HOST,
+  DB_PORT: process.env.DB_PORT,
+  DB_USER: process.env.DB_USER,
+  DB_PASSWORD: process.env.DB_PASSWORD,
+  DB_NAME: process.env.DB_NAME,
+  USE_IN_MEMORY_DB: process.env.USE_IN_MEMORY_DB ?? "false"
+});
+
+export const env = {
+  port: rawEnv.PORT,
+  corsOrigin: rawEnv.CORS_ORIGIN,
+  useInMemoryDb: rawEnv.USE_IN_MEMORY_DB,
+  mysql: rawEnv.USE_IN_MEMORY_DB
+    ? undefined
+    : {
+        host: rawEnv.DB_HOST ?? "localhost",
+        port: rawEnv.DB_PORT ?? 3306,
+        user: rawEnv.DB_USER ?? "root",
+        password: rawEnv.DB_PASSWORD ?? "",
+        database: rawEnv.DB_NAME ?? "budget_tracker"
+      }
+};

--- a/backend/src/config/store.ts
+++ b/backend/src/config/store.ts
@@ -1,0 +1,15 @@
+import { createBudgetStore } from "../store/index.js";
+import { env } from "./env.js";
+
+export const budgetStore = createBudgetStore({
+  useInMemory: env.useInMemoryDb,
+  mysql: env.mysql
+    ? {
+        host: env.mysql.host,
+        port: env.mysql.port,
+        user: env.mysql.user,
+        password: env.mysql.password,
+        database: env.mysql.database
+      }
+    : undefined
+});

--- a/backend/src/controllers/categoryController.ts
+++ b/backend/src/controllers/categoryController.ts
@@ -1,0 +1,49 @@
+import { Request, Response } from "express";
+import { z } from "zod";
+import { budgetStore } from "../config/store.js";
+
+const categorySchema = z.object({
+  name: z.string().min(1)
+});
+
+const subcategorySchema = z.object({
+  name: z.string().min(1)
+});
+
+export const getCategories = async (_req: Request, res: Response) => {
+  const categories = await budgetStore.getCategories();
+  res.json(categories);
+};
+
+export const createCategory = async (req: Request, res: Response) => {
+  try {
+    const payload = categorySchema.parse(req.body);
+    const category = await budgetStore.createCategory(payload);
+    res.status(201).json(category);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      res.status(400).json({ message: "Invalid category payload", details: error.flatten() });
+      return;
+    }
+    res.status(500).json({ message: (error as Error).message });
+  }
+};
+
+export const createSubcategory = async (req: Request, res: Response) => {
+  try {
+    const payload = subcategorySchema.parse(req.body);
+    const categoryId = Number(req.params.categoryId);
+    if (!Number.isInteger(categoryId) || categoryId <= 0) {
+      res.status(400).json({ message: "categoryId must be a positive integer" });
+      return;
+    }
+    const subcategory = await budgetStore.createSubcategory(categoryId, payload);
+    res.status(201).json(subcategory);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      res.status(400).json({ message: "Invalid subcategory payload", details: error.flatten() });
+      return;
+    }
+    res.status(500).json({ message: (error as Error).message });
+  }
+};

--- a/backend/src/controllers/expenseController.ts
+++ b/backend/src/controllers/expenseController.ts
@@ -1,0 +1,34 @@
+import { Request, Response } from "express";
+import { z } from "zod";
+import { budgetStore } from "../config/store.js";
+
+const expenseSchema = z.object({
+  userId: z.coerce.number().int().positive(),
+  amount: z.coerce.number().positive(),
+  date: z.string(),
+  description: z.string().min(1).optional(),
+  categoryId: z.coerce.number().int().positive(),
+  subcategoryId: z.coerce.number().int().positive().nullable().optional()
+});
+
+export const getExpenses = async (_req: Request, res: Response) => {
+  const expenses = await budgetStore.getExpenses();
+  res.json(expenses);
+};
+
+export const createExpense = async (req: Request, res: Response) => {
+  try {
+    const payload = expenseSchema.parse(req.body);
+    const expense = await budgetStore.createExpense({
+      ...payload,
+      subcategoryId: payload.subcategoryId ?? null
+    });
+    res.status(201).json(expense);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      res.status(400).json({ message: "Invalid expense payload", details: error.flatten() });
+      return;
+    }
+    res.status(500).json({ message: (error as Error).message });
+  }
+};

--- a/backend/src/controllers/incomeController.ts
+++ b/backend/src/controllers/incomeController.ts
@@ -1,0 +1,30 @@
+import { Request, Response } from "express";
+import { z } from "zod";
+import { budgetStore } from "../config/store.js";
+
+const incomeSchema = z.object({
+  userId: z.coerce.number().int().positive(),
+  amount: z.coerce.number().positive(),
+  date: z.string(),
+  source: z.string().min(1).optional(),
+  recurring: z.coerce.boolean().default(false)
+});
+
+export const getIncomes = async (_req: Request, res: Response) => {
+  const incomes = await budgetStore.getIncomes();
+  res.json(incomes);
+};
+
+export const createIncome = async (req: Request, res: Response) => {
+  try {
+    const payload = incomeSchema.parse(req.body);
+    const income = await budgetStore.createIncome(payload);
+    res.status(201).json(income);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      res.status(400).json({ message: "Invalid income payload", details: error.flatten() });
+      return;
+    }
+    res.status(500).json({ message: (error as Error).message });
+  }
+};

--- a/backend/src/routes/categoryRoutes.ts
+++ b/backend/src/routes/categoryRoutes.ts
@@ -1,0 +1,10 @@
+import { Router } from "express";
+import { createCategory, createSubcategory, getCategories } from "../controllers/categoryController.js";
+
+const router = Router();
+
+router.get("/", getCategories);
+router.post("/", createCategory);
+router.post("/:categoryId/subcategories", createSubcategory);
+
+export default router;

--- a/backend/src/routes/expenseRoutes.ts
+++ b/backend/src/routes/expenseRoutes.ts
@@ -1,0 +1,9 @@
+import { Router } from "express";
+import { createExpense, getExpenses } from "../controllers/expenseController.js";
+
+const router = Router();
+
+router.get("/", getExpenses);
+router.post("/", createExpense);
+
+export default router;

--- a/backend/src/routes/healthRoutes.ts
+++ b/backend/src/routes/healthRoutes.ts
@@ -1,0 +1,13 @@
+import { Router } from "express";
+import { env } from "../config/env.js";
+
+const router = Router();
+
+router.get("/", (_req, res) => {
+  res.json({
+    status: "ok",
+    mode: env.useInMemoryDb ? "in-memory" : "mysql"
+  });
+});
+
+export default router;

--- a/backend/src/routes/incomeRoutes.ts
+++ b/backend/src/routes/incomeRoutes.ts
@@ -1,0 +1,9 @@
+import { Router } from "express";
+import { createIncome, getIncomes } from "../controllers/incomeController.js";
+
+const router = Router();
+
+router.get("/", getIncomes);
+router.post("/", createIncome);
+
+export default router;

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -1,0 +1,14 @@
+import { Router } from "express";
+import categoryRoutes from "./categoryRoutes.js";
+import expenseRoutes from "./expenseRoutes.js";
+import healthRoutes from "./healthRoutes.js";
+import incomeRoutes from "./incomeRoutes.js";
+
+const router = Router();
+
+router.use("/health", healthRoutes);
+router.use("/incomes", incomeRoutes);
+router.use("/expenses", expenseRoutes);
+router.use("/categories", categoryRoutes);
+
+export default router;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,0 +1,8 @@
+import app from "./app.js";
+import { env } from "./config/env.js";
+
+const port = env.port ?? 4000;
+
+app.listen(port, () => {
+  console.log(`Budget Tracker API running on port ${port}`);
+});

--- a/backend/src/store/BudgetStore.ts
+++ b/backend/src/store/BudgetStore.ts
@@ -1,0 +1,11 @@
+import { Category, CategoryInput, Expense, ExpenseInput, Income, IncomeInput, Subcategory, SubcategoryInput } from "../types/budget.js";
+
+export interface BudgetStore {
+  getIncomes(): Promise<Income[]>;
+  createIncome(input: IncomeInput): Promise<Income>;
+  getExpenses(): Promise<Expense[]>;
+  createExpense(input: ExpenseInput): Promise<Expense>;
+  getCategories(): Promise<Category[]>;
+  createCategory(input: CategoryInput): Promise<Category>;
+  createSubcategory(categoryId: number, input: SubcategoryInput): Promise<Subcategory>;
+}

--- a/backend/src/store/InMemoryBudgetStore.ts
+++ b/backend/src/store/InMemoryBudgetStore.ts
@@ -1,0 +1,141 @@
+import { randomUUID } from "crypto";
+import {
+  BudgetStore
+} from "./BudgetStore.js";
+import {
+  Category,
+  CategoryInput,
+  Expense,
+  ExpenseInput,
+  Income,
+  IncomeInput,
+  Subcategory,
+  SubcategoryInput
+} from "../types/budget.js";
+
+const uuidToNumericId = (() => {
+  let counter = 1;
+  const map = new Map<string, number>();
+  return (uuid: string) => {
+    if (!map.has(uuid)) {
+      map.set(uuid, counter++);
+    }
+    return map.get(uuid)!;
+  };
+})();
+
+const nextId = () => uuidToNumericId(randomUUID());
+
+export class InMemoryBudgetStore implements BudgetStore {
+  private incomes: Income[] = [];
+  private expenses: Expense[] = [];
+  private categories: Category[] = [];
+
+  constructor() {
+    this.seed();
+  }
+
+  private seed() {
+    const foodCategory: Category = {
+      id: nextId(),
+      name: "Food",
+      subcategories: []
+    };
+    const housingCategory: Category = {
+      id: nextId(),
+      name: "Housing",
+      subcategories: []
+    };
+
+    const groceriesSubcategory: Subcategory = {
+      id: nextId(),
+      categoryId: foodCategory.id,
+      name: "Groceries"
+    };
+    const diningOutSubcategory: Subcategory = {
+      id: nextId(),
+      categoryId: foodCategory.id,
+      name: "Dining Out"
+    };
+    const rentSubcategory: Subcategory = {
+      id: nextId(),
+      categoryId: housingCategory.id,
+      name: "Rent"
+    };
+
+    foodCategory.subcategories.push(groceriesSubcategory, diningOutSubcategory);
+    housingCategory.subcategories.push(rentSubcategory);
+
+    this.categories.push(foodCategory, housingCategory);
+
+    this.incomes.push({
+      id: nextId(),
+      userId: 1,
+      amount: 3200,
+      date: new Date().toISOString().split("T")[0],
+      source: "Salary",
+      recurring: true
+    });
+
+    this.expenses.push({
+      id: nextId(),
+      userId: 1,
+      amount: 450,
+      date: new Date().toISOString().split("T")[0],
+      description: "Weekly groceries",
+      categoryId: foodCategory.id,
+      subcategoryId: groceriesSubcategory.id
+    });
+  }
+
+  async getIncomes(): Promise<Income[]> {
+    return [...this.incomes];
+  }
+
+  async createIncome(input: IncomeInput): Promise<Income> {
+    const income: Income = { ...input, id: nextId() };
+    this.incomes.push(income);
+    return income;
+  }
+
+  async getExpenses(): Promise<Expense[]> {
+    return [...this.expenses];
+  }
+
+  async createExpense(input: ExpenseInput): Promise<Expense> {
+    const expense: Expense = { ...input, id: nextId() };
+    this.expenses.push(expense);
+    return expense;
+  }
+
+  async getCategories(): Promise<Category[]> {
+    return this.categories.map((category) => ({
+      ...category,
+      subcategories: [...category.subcategories]
+    }));
+  }
+
+  async createCategory(input: CategoryInput): Promise<Category> {
+    const category: Category = {
+      id: nextId(),
+      name: input.name,
+      subcategories: []
+    };
+    this.categories.push(category);
+    return category;
+  }
+
+  async createSubcategory(categoryId: number, input: SubcategoryInput): Promise<Subcategory> {
+    const category = this.categories.find((item) => item.id === categoryId);
+    if (!category) {
+      throw new Error(`Category ${categoryId} not found`);
+    }
+    const subcategory: Subcategory = {
+      id: nextId(),
+      categoryId,
+      name: input.name
+    };
+    category.subcategories.push(subcategory);
+    return subcategory;
+  }
+}

--- a/backend/src/store/MySqlBudgetStore.ts
+++ b/backend/src/store/MySqlBudgetStore.ts
@@ -1,0 +1,161 @@
+import mysql from "mysql2/promise";
+import {
+  BudgetStore
+} from "./BudgetStore.js";
+import {
+  Category,
+  CategoryInput,
+  Expense,
+  ExpenseInput,
+  Income,
+  IncomeInput,
+  Subcategory,
+  SubcategoryInput
+} from "../types/budget.js";
+
+export interface MySqlBudgetStoreOptions {
+  host: string;
+  port: number;
+  user: string;
+  password: string;
+  database: string;
+}
+
+export class MySqlBudgetStore implements BudgetStore {
+  private pool: mysql.Pool;
+
+  constructor(options: MySqlBudgetStoreOptions) {
+    this.pool = mysql.createPool({
+      ...options,
+      waitForConnections: true,
+      connectionLimit: 10,
+      namedPlaceholders: true
+    });
+  }
+
+  private async mapIncome(row: any): Promise<Income> {
+    return {
+      id: row.income_id,
+      userId: row.user_id,
+      amount: Number(row.amount),
+      date: row.date instanceof Date ? row.date.toISOString().split("T")[0] : row.date,
+      source: row.source ?? undefined,
+      recurring: Boolean(row.recurring)
+    };
+  }
+
+  private async mapExpense(row: any): Promise<Expense> {
+    return {
+      id: row.expense_id,
+      userId: row.user_id,
+      amount: Number(row.amount),
+      date: row.date instanceof Date ? row.date.toISOString().split("T")[0] : row.date,
+      description: row.description ?? undefined,
+      categoryId: row.category_id,
+      subcategoryId: row.subcategory_id ?? null
+    };
+  }
+
+  async getIncomes(): Promise<Income[]> {
+    const [rows] = await this.pool.query("SELECT * FROM incomes ORDER BY date DESC, income_id DESC");
+    return Promise.all((rows as mysql.RowDataPacket[]).map((row) => this.mapIncome(row)));
+  }
+
+  async createIncome(input: IncomeInput): Promise<Income> {
+    const [result] = await this.pool.execute<mysql.ResultSetHeader>(
+      `INSERT INTO incomes (user_id, amount, date, source, recurring)
+       VALUES (:userId, :amount, :date, :source, :recurring)`
+      , {
+        userId: input.userId,
+        amount: input.amount,
+        date: input.date,
+        source: input.source ?? null,
+        recurring: input.recurring ? 1 : 0
+      }
+    );
+    const insertedId = result.insertId;
+    return {
+      id: insertedId,
+      ...input
+    };
+  }
+
+  async getExpenses(): Promise<Expense[]> {
+    const [rows] = await this.pool.query(
+      `SELECT * FROM expenses ORDER BY date DESC, expense_id DESC`
+    );
+    return Promise.all((rows as mysql.RowDataPacket[]).map((row) => this.mapExpense(row)));
+  }
+
+  async createExpense(input: ExpenseInput): Promise<Expense> {
+    const [result] = await this.pool.execute<mysql.ResultSetHeader>(
+      `INSERT INTO expenses (user_id, amount, date, description, category_id, subcategory_id)
+       VALUES (:userId, :amount, :date, :description, :categoryId, :subcategoryId)`
+      , {
+        userId: input.userId,
+        amount: input.amount,
+        date: input.date,
+        description: input.description ?? null,
+        categoryId: input.categoryId,
+        subcategoryId: input.subcategoryId ?? null
+      }
+    );
+    const insertedId = result.insertId;
+    return {
+      id: insertedId,
+      ...input
+    };
+  }
+
+  async getCategories(): Promise<Category[]> {
+    const [categoryRows] = await this.pool.query("SELECT * FROM categories ORDER BY name ASC");
+    const [subcategoryRows] = await this.pool.query("SELECT * FROM subcategories ORDER BY name ASC");
+
+    const subcategoriesByCategory = new Map<number, Subcategory[]>();
+    for (const row of subcategoryRows as mysql.RowDataPacket[]) {
+      const subcategory: Subcategory = {
+        id: row.subcategory_id,
+        categoryId: row.category_id,
+        name: row.name
+      };
+      const list = subcategoriesByCategory.get(subcategory.categoryId) ?? [];
+      list.push(subcategory);
+      subcategoriesByCategory.set(subcategory.categoryId, list);
+    }
+
+    return (categoryRows as mysql.RowDataPacket[]).map((row) => ({
+      id: row.category_id,
+      name: row.name,
+      subcategories: subcategoriesByCategory.get(row.category_id) ?? []
+    }));
+  }
+
+  async createCategory(input: CategoryInput): Promise<Category> {
+    const [result] = await this.pool.execute<mysql.ResultSetHeader>(
+      `INSERT INTO categories (name) VALUES (:name)`
+      , {
+        name: input.name
+      }
+    );
+    return {
+      id: result.insertId,
+      name: input.name,
+      subcategories: []
+    };
+  }
+
+  async createSubcategory(categoryId: number, input: SubcategoryInput): Promise<Subcategory> {
+    const [result] = await this.pool.execute<mysql.ResultSetHeader>(
+      `INSERT INTO subcategories (category_id, name) VALUES (:categoryId, :name)`
+      , {
+        categoryId,
+        name: input.name
+      }
+    );
+    return {
+      id: result.insertId,
+      categoryId,
+      name: input.name
+    };
+  }
+}

--- a/backend/src/store/index.ts
+++ b/backend/src/store/index.ts
@@ -1,0 +1,26 @@
+import { BudgetStore } from "./BudgetStore.js";
+import { InMemoryBudgetStore } from "./InMemoryBudgetStore.js";
+import { MySqlBudgetStore } from "./MySqlBudgetStore.js";
+
+interface StoreConfig {
+  useInMemory: boolean;
+  mysql?: {
+    host: string;
+    port: number;
+    user: string;
+    password: string;
+    database: string;
+  };
+}
+
+export const createBudgetStore = (config: StoreConfig): BudgetStore => {
+  if (config.useInMemory) {
+    return new InMemoryBudgetStore();
+  }
+
+  if (!config.mysql) {
+    throw new Error("MySQL configuration is required when USE_IN_MEMORY_DB is false");
+  }
+
+  return new MySqlBudgetStore(config.mysql);
+};

--- a/backend/src/types/budget.ts
+++ b/backend/src/types/budget.ts
@@ -1,0 +1,35 @@
+export interface Income {
+  id: number;
+  userId: number;
+  amount: number;
+  date: string;
+  source?: string;
+  recurring: boolean;
+}
+
+export interface Expense {
+  id: number;
+  userId: number;
+  amount: number;
+  date: string;
+  description?: string;
+  categoryId: number;
+  subcategoryId?: number | null;
+}
+
+export interface Category {
+  id: number;
+  name: string;
+  subcategories: Subcategory[];
+}
+
+export interface Subcategory {
+  id: number;
+  categoryId: number;
+  name: string;
+}
+
+export type IncomeInput = Omit<Income, "id">;
+export type ExpenseInput = Omit<Expense, "id">;
+export type CategoryInput = Pick<Category, "name">;
+export type SubcategoryInput = Pick<Subcategory, "name">;

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- scaffold a dedicated Express + TypeScript backend with environment-driven configuration
- implement in-memory and MySQL-backed data stores alongside validated REST endpoints for incomes, expenses, and categories
- document backend usage with setup instructions and database schema guidance

## Testing
- npm install *(fails: registry access is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d66b3407bc832cb01ec6748b932a92