### PR TITLE
Add Procfile for Railway deployment

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}

--- a/README.md
+++ b/README.md
@@ -210,3 +210,15 @@ uvicorn app.main:app --reload
 ```
 
 The interactive API documentation is available at `http://localhost:8000/docs` after the server starts.
+
+### Deployment on Railway
+
+Railway requires an explicit start command for custom Python projects. This repository now includes a
+`Procfile` with the following entry so the service can be launched automatically during deployment:
+
+```
+web: uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}
+```
+
+If you prefer to override the default command, you can adjust the `Procfile` or configure the start
+command directly in the Railway dashboard.


### PR DESCRIPTION
## Summary
- add a Procfile so Railway can start the FastAPI backend with uvicorn
- document the Railway deployment command in the README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d66b9b06a4832c8c2eeba11f6a06c4