### PR TITLE
Improve dashboard layout for mobile quick entry

### DIFF
--- a/frontend/src/data/translations.js
+++ b/frontend/src/data/translations.js
@@ -31,6 +31,10 @@ export const translations = {
       }
     },
     dashboard: {
+      sections: {
+        quickEntry: 'Añadir movimientos',
+        dataInsights: 'Datos y estadísticas'
+      },
       quickAdd: {
         title: 'Registro rápido',
         description: 'Captura ingresos y gastos con toques culturales personalizados.',
@@ -245,6 +249,10 @@ export const translations = {
       }
     },
     dashboard: {
+      sections: {
+        quickEntry: 'Registra movimenti',
+        dataInsights: 'Dati e statistiche'
+      },
       quickAdd: {
         title: 'Aggiunta rapida',
         description: 'Registra entrate e uscite con tocchi culturali personalizzati.',
@@ -459,6 +467,10 @@ export const translations = {
       }
     },
     dashboard: {
+      sections: {
+        quickEntry: 'Add new entry',
+        dataInsights: 'Data & insights'
+      },
       quickAdd: {
         title: 'Quick add',
         description: 'Capture income and expenses with personalized cultural flair.',

--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -37,27 +37,44 @@ export default function DashboardPage() {
 
   return (
     <div className="dashboard-page">
-      <section className="kpi-strip">
-        {localizedKpis.map((kpi) => (
-          <KpiCard key={kpi.id} {...kpi} />
-        ))}
+      <section className="quick-entry-section" aria-labelledby="quick-entry-heading">
+        <header className="section-header">
+          <h2 id="quick-entry-heading" className="section-title">
+            {t('dashboard.sections.quickEntry')}
+          </h2>
+        </header>
+        <QuickAddCard />
       </section>
-      <div className="dashboard-grid">
-        <div className="dashboard-left">
-          <CulturalSpotlight item={spotlight} />
-          <QuickAddCard />
-          <div className="spotlight-toggle">
-            <button type="button" onClick={() => setSpotlightIndex((index) => (index === 0 ? 1 : 0))}>
-              {t('dashboard.spotlightToggle')}
-            </button>
+
+      <section className="insights-section" aria-labelledby="insights-heading">
+        <header className="section-header">
+          <h2 id="insights-heading" className="section-title">
+            {t('dashboard.sections.dataInsights')}
+          </h2>
+        </header>
+
+        <section className="kpi-strip">
+          {localizedKpis.map((kpi) => (
+            <KpiCard key={kpi.id} {...kpi} />
+          ))}
+        </section>
+
+        <div className="dashboard-grid">
+          <div className="dashboard-left">
+            <CulturalSpotlight item={spotlight} />
+            <div className="spotlight-toggle">
+              <button type="button" onClick={() => setSpotlightIndex((index) => (index === 0 ? 1 : 0))}>
+                {t('dashboard.spotlightToggle')}
+              </button>
+            </div>
+          </div>
+          <div className="dashboard-right">
+            <ExpenseDonut data={expenseBreakdown} />
+            <IncomeStreamsChart data={incomeStreams} />
+            <TimelineCard transactions={transactions} />
           </div>
         </div>
-        <div className="dashboard-right">
-          <ExpenseDonut data={expenseBreakdown} />
-          <IncomeStreamsChart data={incomeStreams} />
-          <TimelineCard transactions={transactions} />
-        </div>
-      </div>
+      </section>
     </div>
   );
 }

--- a/frontend/src/styles/theme.css
+++ b/frontend/src/styles/theme.css
@@ -319,11 +319,39 @@ body {
   margin: 0 0 0.5rem;
 }
 
+.dashboard-page {
+  display: grid;
+  gap: 2rem;
+}
+
+.quick-entry-section,
+.insights-section {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.quick-entry-section .quick-add-card {
+  max-width: 440px;
+}
+
+.section-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+}
+
+.section-title {
+  margin: 0;
+  font-family: var(--font-heading);
+  font-size: clamp(1.5rem, 3vw, 2rem);
+}
+
 .kpi-strip {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: 1.5rem;
-  margin-bottom: 2rem;
 }
 
 .kpi-card {
@@ -811,6 +839,10 @@ body {
 }
 
 @media (max-width: 1200px) {
+  .quick-entry-section .quick-add-card {
+    max-width: 100%;
+  }
+
   .dashboard-grid {
     grid-template-columns: 1fr;
   }
@@ -836,6 +868,17 @@ body {
 
   .app-main {
     padding: 1.5rem;
+  }
+
+  .section-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.35rem;
+  }
+
+  .quick-entry-section,
+  .insights-section {
+    gap: 1.25rem;
   }
 
   .login-content {


### PR DESCRIPTION
## Summary
- move the dashboard quick entry card into a dedicated section at the top of the page
- add translated section headings to distinguish quick entry from insights content
- update dashboard styling for better spacing and responsive behavior on smaller screens

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6c5f5e23c832c831cad2e9a3cc123