### PR TITLE
Improve entry modal usability

### DIFF
--- a/frontend/src/components/modals/AddEntryModal.jsx
+++ b/frontend/src/components/modals/AddEntryModal.jsx
@@ -2,23 +2,23 @@ import { useState } from 'react';
 import { useAppContext } from '../../context/AppContext.jsx';
 import PillButton from '../shared/PillButton.jsx';
 
-const initialForm = {
+const createInitialForm = () => ({
   amount: '',
-  date: '',
+  date: new Date().toISOString().split('T')[0],
   description: '',
   category: 'groceries',
   split: 50
-};
+});
 
 const categories = ['groceries', 'transport', 'housing', 'leisure'];
 
 export default function AddEntryModal() {
   const { modalState, closeModal, setModalTab, t } = useAppContext();
-  const [form, setForm] = useState(initialForm);
+  const [form, setForm] = useState(createInitialForm());
 
   const handleClose = () => {
     closeModal();
-    setForm(initialForm);
+    setForm(createInitialForm());
   };
 
   const handleChange = (evt) => {

--- a/frontend/src/styles/theme.css
+++ b/frontend/src/styles/theme.css
@@ -752,24 +752,26 @@ body {
   position: fixed;
   inset: 0;
   background: rgba(15, 24, 46, 0.6);
-  display: grid;
-  place-items: center;
-  padding: 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  overflow-y: auto;
   z-index: 30;
 }
 
 .modal-card {
-  width: min(640px, 100%);
+  width: min(420px, 100%);
   background: white;
   border-radius: var(--radius-lg);
-  box-shadow: 0 30px 60px rgba(31, 60, 136, 0.3);
+  box-shadow: 0 25px 50px rgba(31, 60, 136, 0.25);
   overflow: hidden;
   display: grid;
-  gap: 1.5rem;
+  gap: 1.25rem;
 }
 
 .modal-header {
-  padding: 1.75rem 2rem 0;
+  padding: 1.25rem 1.5rem 0;
   background: linear-gradient(135deg, var(--fiesta-red), var(--mediterranean-navy));
   color: white;
 }
@@ -799,7 +801,7 @@ body {
 }
 
 .modal-form {
-  padding: 0 2rem 2rem;
+  padding: 0 1.5rem 1.5rem;
   display: grid;
   gap: 1.2rem;
 }
@@ -836,6 +838,35 @@ body {
   display: flex;
   gap: 0.75rem;
   justify-content: flex-end;
+}
+
+@media (max-width: 640px) {
+  .modal-overlay {
+    align-items: flex-start;
+  }
+
+  .modal-card {
+    border-radius: var(--radius-md);
+  }
+
+  .modal-header {
+    padding: 1rem 1.25rem 0;
+  }
+
+  .modal-form {
+    padding: 0 1.25rem 1.25rem;
+    gap: 1rem;
+  }
+
+  .modal-tabs {
+    flex-wrap: wrap;
+    gap: 0.75rem;
+  }
+
+  .modal-tab {
+    flex: 1 1 140px;
+    text-align: center;
+  }
 }
 
 @media (max-width: 1200px) {


### PR DESCRIPTION
## Summary
- default the add entry form date to the current day whenever the modal opens
- tighten the modal layout sizing and spacing so it is easier to use on smaller screens
- allow the modal overlay to scroll and adjust controls for better mobile ergonomics

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6caccae5c832ca90894a857de868f